### PR TITLE
#4 Fixed mobile view by falling back to Interval

### DIFF
--- a/README - MIRROR.md
+++ b/README - MIRROR.md
@@ -31,7 +31,7 @@ Available mirrors:
 ## Usage
 
 Once installed, you should be able to see the vibrant Play-All button when visiting or navigating to the videos section of a YouTube channel.
-Simply clicking it or opening the link in a new tab will send you to the newest video playing inside the "Uploads from..." playlist.
+Simply clicking it or opening the link in a new tab will send you to the newest video playing inside the "Videos" playlist.
 
 It may take a few seconds for the button to be dynamically added.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Available mirrors:
 ## Usage
 
 Once installed, you should be able to see the vibrant Play-All button when visiting or navigating to the videos section of a YouTube channel.
-Simply clicking it or opening the link in a new tab will send you to the newest video playing inside the "Uploads from..." playlist.
+Simply clicking it or opening the link in a new tab will send you to the newest video playing inside the "Videos" playlist.
 
 It may take a few seconds for the button to be dynamically added.
 


### PR DESCRIPTION
This fixes #4 by falling back to an Interval for mobile due to it not firing the `yt-navigate-finish` Event.